### PR TITLE
Fixed the issue of could not update user role on the Manage Users page.

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -67,7 +67,7 @@ class UserController extends BaseController
 
             $user->setEmail($email);
             $user->setPassword($hash);
-            $user->getRole($role);
+            $user->setRole($role);
             $user->update();
 
             $this->slim->flash('success', 'User updated');


### PR DESCRIPTION
I found a issue of we colud not update user role on the "Manage Users" page. 
It seems we can fix it with using setRole instead of getRole in the function update of UserController.php.
I'm happy if the fix could be useful. 